### PR TITLE
Python 3.9 literal comparison fix.

### DIFF
--- a/build/buck50.py
+++ b/build/buck50.py
@@ -1403,9 +1403,9 @@ class FileName(object):
         (dir, file) = os.path.split(text)
         if self.__suffix and file.endswith(self.__suffix):
             file = file[:-len(self.__suffix)]
-        names  = os.listdir(None if dir is '' else dir)
+        names  = os.listdir(None if dir == '' else dir)
         names.append('..')
-        if dir is not '' and not dir.endswith('/'):
+        if dir != '' and not dir.endswith('/'):
             dir = dir + '/'
         dirs   = [    '%s%s/' % (dir, name)
                   for name


### PR DESCRIPTION
Tiny fix, eliminates literal comparison warnings on python 3.9. Although I believe it reads much better with the keywords. Leaving them as they are will generate just two warnings on startup so whatever the maintainer decides is better 😄 